### PR TITLE
CVE-2022-1292 openssl fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && \
     && \
     rm -rf /var/lib/apt/lists/*
 
+# CVE-2022-1292 openssl fix
+RUN apt-get update &&  apt-get --only-upgrade install openssl libssl1.1 -y && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /opt
 
 WORKDIR /opt


### PR DESCRIPTION
CVE-2022-1292: OS Command Injection Issue, effecting openssl versions <1.1.1n-0+deb11u2.

CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1292
DSA: dsa-5139: https://www.debian.org/security/2022/dsa-5139
Issue (CVE-2022-1292 openssl vulnerability in Python 3.8-slim-bullseye): https://github.com/docker-library/python/issues/728