### PR TITLE
Add logging for presence set errors

### DIFF
--- a/src/retirement_fee_info/main.py
+++ b/src/retirement_fee_info/main.py
@@ -13,7 +13,7 @@ from ..utils import get_discord_client, \
 BOT_TOKEN = os.environ["DISCORD_BOT_TOKEN"]
 
 # Initialized Discord client
-client = get_discord_client(presences_intent=True)
+client = get_discord_client()
 
 sg = Subgrounds()
 
@@ -85,6 +85,7 @@ async def on_ready():
 async def update_info():
     offset_amount, offset = get_info()
 
+    print(offset_amount, offset)
     if offset_amount and offset is not None:
 
         offset_text = f'Retired {offset}: {prettify_number(offset_amount)}t'

--- a/src/retirement_fee_info/main.py
+++ b/src/retirement_fee_info/main.py
@@ -13,7 +13,7 @@ from ..utils import get_discord_client, \
 BOT_TOKEN = os.environ["DISCORD_BOT_TOKEN"]
 
 # Initialized Discord client
-client = get_discord_client()
+client = get_discord_client(presences_intent=True)
 
 sg = Subgrounds()
 
@@ -95,8 +95,7 @@ async def update_info():
         total_text = 'in the last 7d'
         success = await update_presence(
             client,
-            total_text,
-            type='playing'
+            total_text
         )
         if not success:
             return

--- a/src/utils.py
+++ b/src/utils.py
@@ -81,7 +81,8 @@ async def update_presence(client, text, type='watching'):
             )
         )
         return True
-    except discord.errors.HTTPException:
+    except discord.errors.HTTPException as e:
+        print("Error updating presence: ", e)
         return False
 
 


### PR DESCRIPTION
Trying to figure out why the retirement info bot is missing the "in the last 7d" line but other bots are working fine with it 
![image](https://github.com/user-attachments/assets/87417cbd-4b8e-4e6c-a833-311088604ec9)
